### PR TITLE
start game overlay resizes to gameboard

### DIFF
--- a/app/components/PlayGame/PlayGame.js
+++ b/app/components/PlayGame/PlayGame.js
@@ -37,6 +37,7 @@ const styles = {
 
 	boardContainer: {
 		position: "relative",
+		display: "inline-block"
 	},
 
 	watcherIcon: {


### PR DESCRIPTION
added just a single css prop to the board container to fix start game overlay not fitting to the gameboard